### PR TITLE
Ensure node and npm are installed on prod servers

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -6,3 +6,7 @@ conda env create -f /tmp/server_env.yml && \
 
 # Install specific versions of torch, torchaudio, and torchvision
 conda run -n myenv pip install torch==2.1.0+cu121 torchaudio==2.1.0+cu121 torchvision==0.16.0+cu121 -f https://download.pytorch.org/whl/torch_stable.html
+
+# Install node
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash
+nvm install 20 


### PR DESCRIPTION
We had a customer reach out because minutes weren't generating for them.

I had forgotten that if you upload a Word document transcript (instead of audio or video file) we will use `npx mammoth` to convert it into plain text before feeding it to the LLM.

This makes sure that we always have node installed, which ensures this code path works.

I already installed node manually on our server, but this will make sure nobody forgets again